### PR TITLE
Added OS check in Makefile to establish the correct executable(s) to use in each recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
+# Check if OS is Windows
+ifeq ($(OS),Windows_NT)
+	PYTHON := python
+	PIP := pip
+else
+	PYTHON := python3
+	PIP := pip3
+endif
+
 make install:
-	pip3 install -r src/app/requirements.txt
+	$(PIP) install -r src/app/requirements.txt
 
 make start:
 	docker-compose up -d --build
@@ -11,4 +20,4 @@ make stop:
 	docker-compose down
 
 make test:
-	python3 -m pytest src
+	$(PYTHON) -m pytest src

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -11,6 +11,10 @@
 # Releases
 <!-- @LatestFirst -->
 
+## [0.1.1] 
+[Multiple Spaces](https://github.com/jrsmth/waffle-bot/milestone/2) (22/02/2024)
+- `#29` Added OS check in Makefile to support differences between Windows and Unix-based OS workflows [![user](https://img.shields.io/badge/haydende-181717.svg?style=flat&logo=github)](https://github.com/haydende)
+
 ## [0.1.0]
 [Multiple Spaces](https://github.com/jrsmth/waffle-bot/milestone/2) (16/02/2024)
 - `#10` Expand project to handle multiple Slack instances [![user](https://img.shields.io/badge/jrsmth-181717.svg?style=flat&logo=github)](https://github.com/jrsmth)
@@ -25,3 +29,4 @@
 
 [0.0.0]: https://github.com/jrsmth/waffle-bot/releases/tag/0.0.0
 [0.1.0]: https://github.com/jrsmth/waffle-bot/compare/0.0.0...0.1.0
+[0.1.1]: https://github.com/jrsmth/waffle-bot/compare/0.1.0...0.1.1


### PR DESCRIPTION
As Windows is the only OS (used within our team) that doesn't natively use python3 or pip3 for the relevant python 3.X.Y executables, I have opted to filter that option out first :) 