### PR TITLE
Fix for messages with newline characters not being rendered properly

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -16,6 +16,7 @@
 [Scroll Command](https://github.com/jrsmth/waffle-bot/milestone/4) (11/04/2024)
 - `#44` Prevent duplicate records for the same streak
 - `#46` Add README Badges (Code Coverage, Workflow, Deployment)
+- `#48` Newline (`\n`) characters are now rendered properly
 
 ## [0.3.0] [![user](https://img.shields.io/badge/adamj335-181717.svg?style=flat&logo=github)](https://github.com/adamj335)
 [Scroll Command](https://github.com/jrsmth/waffle-bot/milestone/4) (18/03/2024)

--- a/src/app/archbishop/archbishop.py
+++ b/src/app/archbishop/archbishop.py
@@ -156,11 +156,8 @@ def construct_blueprint(bolt, config, messages, redis):
                 {
                     "type": "section",
                     "text": {
-                        "type": "mrkdwn",
-                        "text": (
-                                result + " :blush:\n\n"
-                                         "*I am under development*"
-                        ),
+                            "type": "mrkdwn",
+                            "text": f"{result} :blush:\n\n*I am under development*"
                     },
                 }
             ],

--- a/src/app/util/messages/messages.py
+++ b/src/app/util/messages/messages.py
@@ -12,21 +12,19 @@ class Messages:
         self.log = logging.getLogger(__name__)
 
     def load(self, key):
-        message = self.bundle[key]
-        if message is None:
-            self.log.debug(f"[load] Unable to find message for key [{key}]")
-            return ''
-        else:
-            return message
+        message = self.load_with_params(key, None)
+        return message
 
-    def load_with_params(self, key, parameters: list):
+    def load_with_params(self, key, parameters):
         message = self.bundle[key]
         if message is None:
             self.log.debug(f"[load_with_params] Unable to find message for key [{key}]")
             return ''
         else:
-            for index in range(len(parameters)):
-                message = message.replace('{' + str(index) + '}', parameters[index])
+            if isinstance(parameters, list):
+                for index in range(len(parameters)):
+                    message = message.replace('{' + str(index) + '}', parameters[index])
+            message = message.replace("\\n", "\n")
             return message
 
     def load_all(self):

--- a/src/app/util/messages/messages_spec.py
+++ b/src/app/util/messages/messages_spec.py
@@ -13,3 +13,11 @@ class MessagesSpec:
     def should_return_empty_string_for_given_key_that_does_not_exist(self):
         message = self.subject.load("key-1")
         assert message == ""
+
+    def should_include_placeholders_for_key_loaded_without_params(self):
+        message = self.subject.load("key1")
+        assert message == "value1 {0}"
+
+    def should_replace_placeholders_for_key_loaded_with_params(self):
+        message = self.subject.load_with_params("key1", ["Hello there!"])
+        assert message == "value1 Hello there!"

--- a/src/app/util/messages/messages_spec.py
+++ b/src/app/util/messages/messages_spec.py
@@ -21,3 +21,7 @@ class MessagesSpec:
     def should_replace_placeholders_for_key_loaded_with_params(self):
         message = self.subject.load_with_params("key1", ["Hello there!"])
         assert message == "value1 Hello there!"
+
+    def should_replace_newline_chars(self):
+        message = self.subject.load("key2-newline")
+        assert message == "Watch out for that ledge!\n\n\nAhhhhhhhh!"

--- a/src/resources/messages.properties
+++ b/src/resources/messages.properties
@@ -8,8 +8,8 @@ event.request.ignored=Awoken for nothing! Do send word when there is a new Waffl
 ## Result
 result.common.coronation=Vive Rex! The WaffleCrown now rests on your head {0}
 result.common.lose=Unlucky {0}! Your kingdom must rebuild!
-result.common.win=Another battlefield conquered, well done {0}! \n Your score is: {1}
+result.common.win=Another battlefield conquered, well done {0}! \n\n Your score is: {1}
 result.king.lose=Unlucky {0}! The time has come to crown a new King
-result.king.win=Congratulations, Your Highness! Another successful battle \n Your score is: {0}
+result.king.win=Congratulations, Your Highness! Another successful battle \n\n Your score is: {0}
 
 command.scroll.entry={0}. King: {1}, Streak: {2} on the date of {3} \n

--- a/src/resources/test/messages.properties
+++ b/src/resources/test/messages.properties
@@ -1,2 +1,3 @@
 key0=value0
 key1=value1 {0}
+key2-newline=Watch out for that ledge!\n\n\nAhhhhhhhh!


### PR DESCRIPTION
When loaded from `messages.properties` the strings used for logging and responses with `\n` characters will now have those characters replaced with string literal `"\n"`, resulting in these actually being rendered as new lines.

Note: This has only been tested against posts with Waffle Scores. Testing the `/scroll` command may need to be tested once deployed to DEV.

Closes #48 