### PR TITLE
[#57] Resolved bug that prevented a submission from being properly recognised

### DIFF
--- a/src/app/archbishop/archbishop.py
+++ b/src/app/archbishop/archbishop.py
@@ -60,23 +60,31 @@ def construct_blueprint(bolt, config, messages, redis):
         """ Receive and process new waffle score """
         log.debug("[handle_waffle] New Waffle Score received!")
         event = Event(message)
-        group = get_group(event)
-        player = get_player(event, group)
+        event_score = event.get_score()
+        event_streak = event.get_streak()
 
-        log.debug(f"[handle_waffle] Updating player information for [{player.name}]")
-        player.score += event.get_score()
-        player.streak = event.get_streak()
-        player.games += 1
+        if event_score is not None and event_streak is not None:
+            group = get_group(event)
+            player = get_player(event, group)
 
-        log.debug(f"[handle_waffle] Processing result for player score [{player.score}]")
-        result = process_result(group, player)
-        redis.set_complex(group.name, result.group)
+            log.debug(f"[handle_waffle] Updating player information for [{player.name}]")
+            player.score += event_score
+            player.streak = event_streak
+            player.games += 1
 
-        log.debug(f"[handle_waffle] Building response for group [{result.group.name}]")
-        to_channel = event.channel
-        response = present(result.text, to_channel)
+            log.debug(f"[handle_waffle] Processing result for player score [{player.score}]")
+            result = process_result(group, player)
+            redis.set_complex(group.name, result.group)
 
-        say(response)
+            log.debug(f"[handle_waffle] Building response for group [{result.group.name}]")
+            to_channel = event.channel
+            response = present(result.text, to_channel)
+
+            say(response)
+
+        else:
+            log.debug("[handle_waffle] Could not extract data from received event. Disregarding.")
+
         return Response(messages.load("event.request.handled"), status=200)
 
     def get_group(event):

--- a/src/app/model/event/event.py
+++ b/src/app/model/event/event.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from munch import Munch
 
@@ -34,12 +35,21 @@ class Event:
     def get_score(self):
         block: Block = Munch.fromDict(self.blocks[0])
         elements: [Element] = block.elements[0].elements
-        score_text = [elem for elem in elements if (hasattr(elem, "text") and "/5" in elem.text)][0].text
-        score = re.split(' ', score_text, 1)[1][0]
-        return int(0 if score == 'X' else score[0])
+        score_text = self._search_elements_for_expr(elements, "#waffle[0-9]+ [0-5]/[0-5]")
+        if score_text is not None:
+            score = re.split(' ', score_text, 1)[1][0]
+            return int(0 if score == 'X' else score[0])
 
     def get_streak(self):
         block: Block = Munch.fromDict(self.blocks[0])
         elements: [Element] = block.elements[0].elements
-        streak_element: Element = [elem for elem in elements if (hasattr(elem, "text") and "streak" in elem.text)][0]
-        return int(streak_element.text.split(" ")[2].strip("\n"))
+        streak_text = self._search_elements_for_expr(elements, "streak: [0-9]*\n")
+        if streak_text is not None:
+            return int(streak_text.split(" ")[1].strip("\n"))
+
+    @staticmethod
+    def _search_elements_for_expr(elements, expr):
+        for elem in elements:
+            if hasattr(elem, "text") and re.search(expr, elem.text) is not None:
+                return re.findall(expr, elem.text)[0]
+

--- a/src/app/model/event/event_spec.py
+++ b/src/app/model/event/event_spec.py
@@ -1,0 +1,89 @@
+import json
+from from_root import from_root
+from src.app.model.event.event import Event
+
+
+class EventSpec:
+
+    def should_extract_when_waffle_is_only_text_present(self):
+        with open(from_root("resources", "test", "event_samples", "event_waffle_score_nothing_else.json")) as event_file:
+            event_dict = json.load(event_file)
+
+        event = Event(event_dict)
+
+        actual_score = event.get_score()
+        actual_streak = event.get_streak()
+
+        assert 0 == actual_score
+        assert 4 == actual_streak
+
+    def should_extract_when_waffle_is_before_short_text(self):
+        with open(from_root("resources", "test", "event_samples", "event_waffle_score_short_text_after.json")) as event_file:
+            event_dict = json.load(event_file)
+
+        event = Event(event_dict)
+
+        actual_score = event.get_score()
+        actual_streak = event.get_streak()
+
+        assert 0 == actual_score
+        assert 4 == actual_streak
+
+    def should_extract_when_waffle_is_after_short_text(self):
+        with open(from_root("resources", "test", "event_samples", "event_waffle_score_short_text_before.json")) as event_file:
+            event_dict = json.load(event_file)
+
+        event = Event(event_dict)
+
+        actual_score = event.get_score()
+        actual_streak = event.get_streak()
+
+        assert 0 == actual_score
+        assert 4 == actual_streak
+
+    def should_extract_when_waffle_is_before_long_text(self):
+        with open(from_root("resources", "test", "event_samples", "event_waffle_score_long_text_after.json")) as event_file:
+            event_dict = json.load(event_file)
+
+        event = Event(event_dict)
+
+        actual_score = event.get_score()
+        actual_streak = event.get_streak()
+
+        assert 3 == actual_score
+        assert 6 == actual_streak
+
+    def should_extract_when_waffle_is_after_long_text(self):
+        with open(from_root("resources", "test", "event_samples", "event_waffle_score_long_text_before.json")) as event_file:
+            event_dict = json.load(event_file)
+
+        event = Event(event_dict)
+
+        actual_score = event.get_score()
+        actual_streak = event.get_streak()
+
+        assert 3 == actual_score
+        assert 6 == actual_streak
+
+    def should_extract_when_waffle_is_after_false_flags(self):
+        with open(from_root("resources", "test", "event_samples", "event_waffle_score_after_fakes.json")) as event_file:
+            event_dict = json.load(event_file)
+
+        event = Event(event_dict)
+
+        actual_score = event.get_score()
+        actual_streak = event.get_streak()
+
+        assert 0 == actual_score
+        assert 4 == actual_streak
+
+    def should_not_extract_from_invalid_post(self):
+        with open(from_root("resources", "test", "event_samples", "event_keyword_match_no_score.json")) as event_file:
+            event_dict = json.load(event_file)
+
+        event = Event(event_dict)
+
+        actual_score = event.get_score()
+        actual_streak = event.get_streak()
+
+        assert actual_score is None and actual_streak is None

--- a/src/resources/messages.properties
+++ b/src/resources/messages.properties
@@ -8,8 +8,8 @@ event.request.ignored=Awoken for nothing! Do send word when there is a new Waffl
 ## Result
 result.common.coronation=Vive Rex! The WaffleCrown now rests on your head {0}
 result.common.lose=Unlucky {0}! Your kingdom must rebuild!
-result.common.win=Another battlefield conquered, well done {0}! \n\n Your score is: {1}
+result.common.win=Another battlefield conquered, well done {0}!\n\nYour score is: {1}
 result.king.lose=Unlucky {0}! The time has come to crown a new King
-result.king.win=Congratulations, Your Highness! Another successful battle \n\n Your score is: {0}
+result.king.win=Congratulations, Your Highness! Another successful battle\n\nYour score is: {0}
 
 command.scroll.entry={0}. King: {1}, Streak: {2} on the date of {3} \n

--- a/src/resources/test/event_samples/event_keyword_match_no_score.json
+++ b/src/resources/test/event_samples/event_keyword_match_no_score.json
@@ -1,0 +1,33 @@
+{
+  "user": "{{USER_INFO}}",
+  "type": "message",
+  "ts": "1714382813.712429",
+  "client_msg_id": "eb5e22c3-0657-4879-bc5c-0c093248cad4",
+  "text": "#waffle #waffle #waffle #waffle! #waffle828 0/5\n\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n:large_green_square::white_large_square::large_green_square::white_large_square::large_green_square:\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n:large_green_square::white_large_square::large_green_square::white_large_square::large_green_square:\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n\n:fire: streak: 4\n<http://wafflegame.net|wafflegame.net>",
+  "team": "T06DQBGR53J",
+  "blocks": [
+    {
+      "type": "rich_text",
+      "block_id": "YC/lV",
+      "elements": [
+        {
+          "type": "rich_text_section",
+          "elements": [
+            {
+              "type": "text",
+              "text": "#waffle #waffle #waffle #waffle! #waffle828\n\n"
+            },
+            {
+              "type": "link",
+              "url": "http://wafflegame.net",
+              "text": "wafflegame.net"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "channel": "C06D1J4T54J",
+  "event_ts": "1714382813.712429",
+  "channel_type": "channel"
+}

--- a/src/resources/test/event_samples/event_waffle_score_after_fakes.json
+++ b/src/resources/test/event_samples/event_waffle_score_after_fakes.json
@@ -1,0 +1,187 @@
+{
+  "user": "{{USER_INFO}}",
+  "type": "message",
+  "ts": "1714382813.712429",
+  "client_msg_id": "eb5e22c3-0657-4879-bc5c-0c093248cad4",
+  "text": "#waffle #waffle #waffle #waffle! #waffle828 0/5\n\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n:large_green_square::white_large_square::large_green_square::white_large_square::large_green_square:\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n:large_green_square::white_large_square::large_green_square::white_large_square::large_green_square:\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n\n:fire: streak: 4\n<http://wafflegame.net|wafflegame.net>",
+  "team": "T06DQBGR53J",
+  "blocks": [
+    {
+      "type": "rich_text",
+      "block_id": "YC/lV",
+      "elements": [
+        {
+          "type": "rich_text_section",
+          "elements": [
+            {
+              "type": "text",
+              "text": "#waffle #waffle #waffle #waffle! #waffle828 0/5\n\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n\n"
+            },
+            {
+              "type": "emoji",
+              "name": "fire",
+              "unicode": "1f525"
+            },
+            {
+              "type": "text",
+              "text": " streak: 4\n"
+            },
+            {
+              "type": "link",
+              "url": "http://wafflegame.net",
+              "text": "wafflegame.net"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "channel": "C06D1J4T54J",
+  "event_ts": "1714382813.712429",
+  "channel_type": "channel"
+}

--- a/src/resources/test/event_samples/event_waffle_score_long_text_after.json
+++ b/src/resources/test/event_samples/event_waffle_score_long_text_after.json
@@ -1,0 +1,870 @@
+{
+  "user": "{{USER_INFO}}",
+  "type": "message",
+  "ts": "1714382813.712429",
+  "client_msg_id": "eb5e22c3-0657-4879-bc5c-0c093248cad4",
+  "text": "sp a c e ?\n\n#waffle828 0/5\n\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n:large_green_square::white_large_square::large_green_square::white_large_square::large_green_square:\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n:large_green_square::white_large_square::large_green_square::white_large_square::large_green_square:\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n\n:fire: streak: 4\n<http://wafflegame.net|wafflegame.net>",
+  "team": "T06DQBGR53J",
+  "blocks": [
+    {
+      "type": "rich_text",
+      "block_id": "RN7Xk",
+      "elements": [
+        {
+          "type": "rich_text_section",
+          "elements": [
+            {
+              "type": "text",
+              "text": "\n\n#waffle832 3/5\n\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n\n"
+            },
+            {
+              "type": "emoji",
+              "name": "fire",
+              "unicode": "1f525"
+            },
+            {
+              "type": "text",
+              "text": " streak: 6\n"
+            },
+            {
+              "type": "link",
+              "url": "http://wafflegame.net",
+              "text": "wafflegame.net"
+            },
+            {
+              "type": "text",
+              "text": "#Worldle #832 (02.05.2024) X/6 (97%)\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_left",
+              "unicode": "2b05-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_right",
+              "unicode": "27a1-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_right",
+              "unicode": "27a1-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_lower_left",
+              "unicode": "2199-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_yellow_square",
+              "unicode": "1f7e8"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_up",
+              "unicode": "2b06-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_yellow_square",
+              "unicode": "1f7e8"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_up",
+              "unicode": "2b06-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "coin",
+              "unicode": "1fa99"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "link",
+              "url": "https://worldle.teuteuf.fr"
+            },
+            {
+              "type": "text",
+              "text": "\n\n"
+            },
+            {
+              "type": "emoji",
+              "name": "camera",
+              "unicode": "1f4f7"
+            },
+            {
+              "type": "text",
+              "text": " #WhereTaken"
+            },
+            {
+              "type": "emoji",
+              "name": "earth_americas",
+              "unicode": "1f30e"
+            },
+            {
+              "type": "text",
+              "text": " #431 (02.05.2024) 4/6\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_yellow_square",
+              "unicode": "1f7e8"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_lower_left",
+              "unicode": "2199-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_upper_left",
+              "unicode": "2196-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_down",
+              "unicode": "2b07-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "tada",
+              "unicode": "1f389"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "star",
+              "unicode": "2b50"
+            },
+            {
+              "type": "emoji",
+              "name": "star",
+              "unicode": "2b50"
+            },
+            {
+              "type": "text",
+              "text": "\n\n"
+            },
+            {
+              "type": "link",
+              "url": "http://wheretaken.teuteuf.fr",
+              "text": "wheretaken.teuteuf.fr"
+            },
+            {
+              "type": "text",
+              "text": "\n\n#WhenTaken #65 (02.05.2024)\n\nI scored 811/1000 "
+            },
+            {
+              "type": "emoji",
+              "name": "tada",
+              "unicode": "1f389"
+            },
+            {
+              "type": "text",
+              "text": "\n\n"
+            },
+            {
+              "type": "emoji",
+              "name": "one",
+              "unicode": "0031-fe0f-20e3"
+            },
+            {
+              "type": "text",
+              "text": " "
+            },
+            {
+              "type": "emoji",
+              "name": "round_pushpin",
+              "unicode": "1f4cd"
+            },
+            {
+              "type": "text",
+              "text": " 758 km - "
+            },
+            {
+              "type": "emoji",
+              "name": "spiral_calendar_pad",
+              "unicode": "1f5d3-fe0f"
+            },
+            {
+              "type": "text",
+              "text": " 2 yrs - "
+            },
+            {
+              "type": "emoji",
+              "name": "zap",
+              "unicode": "26a1"
+            },
+            {
+              "type": "text",
+              "text": " 175 / 200\n"
+            },
+            {
+              "type": "emoji",
+              "name": "two",
+              "unicode": "0032-fe0f-20e3"
+            },
+            {
+              "type": "text",
+              "text": " "
+            },
+            {
+              "type": "emoji",
+              "name": "round_pushpin",
+              "unicode": "1f4cd"
+            },
+            {
+              "type": "text",
+              "text": " 5 km - "
+            },
+            {
+              "type": "emoji",
+              "name": "spiral_calendar_pad",
+              "unicode": "1f5d3-fe0f"
+            },
+            {
+              "type": "text",
+              "text": " 10 yrs - "
+            },
+            {
+              "type": "emoji",
+              "name": "zap",
+              "unicode": "26a1"
+            },
+            {
+              "type": "text",
+              "text": " 185 / 200\n"
+            },
+            {
+              "type": "emoji",
+              "name": "three",
+              "unicode": "0033-fe0f-20e3"
+            },
+            {
+              "type": "text",
+              "text": " "
+            },
+            {
+              "type": "emoji",
+              "name": "round_pushpin",
+              "unicode": "1f4cd"
+            },
+            {
+              "type": "text",
+              "text": " 2800 km - "
+            },
+            {
+              "type": "emoji",
+              "name": "spiral_calendar_pad",
+              "unicode": "1f5d3-fe0f"
+            },
+            {
+              "type": "text",
+              "text": " 2 yrs - "
+            },
+            {
+              "type": "emoji",
+              "name": "zap",
+              "unicode": "26a1"
+            },
+            {
+              "type": "text",
+              "text": " 140 / 200\n"
+            },
+            {
+              "type": "emoji",
+              "name": "four",
+              "unicode": "0034-fe0f-20e3"
+            },
+            {
+              "type": "text",
+              "text": " "
+            },
+            {
+              "type": "emoji",
+              "name": "round_pushpin",
+              "unicode": "1f4cd"
+            },
+            {
+              "type": "text",
+              "text": " 62 km - "
+            },
+            {
+              "type": "emoji",
+              "name": "spiral_calendar_pad",
+              "unicode": "1f5d3-fe0f"
+            },
+            {
+              "type": "text",
+              "text": " 9 yrs - "
+            },
+            {
+              "type": "emoji",
+              "name": "zap",
+              "unicode": "26a1"
+            },
+            {
+              "type": "text",
+              "text": " 184 / 200\n"
+            },
+            {
+              "type": "emoji",
+              "name": "five",
+              "unicode": "0035-fe0f-20e3"
+            },
+            {
+              "type": "text",
+              "text": " "
+            },
+            {
+              "type": "emoji",
+              "name": "round_pushpin",
+              "unicode": "1f4cd"
+            },
+            {
+              "type": "text",
+              "text": " 3570 km - "
+            },
+            {
+              "type": "emoji",
+              "name": "spiral_calendar_pad",
+              "unicode": "1f5d3-fe0f"
+            },
+            {
+              "type": "text",
+              "text": " 6 yrs - "
+            },
+            {
+              "type": "emoji",
+              "name": "zap",
+              "unicode": "26a1"
+            },
+            {
+              "type": "text",
+              "text": " 127 / 200\n\n"
+            },
+            {
+              "type": "link",
+              "url": "https://whentaken.com"
+            },
+            {
+              "type": "text",
+              "text": "\n\nBandle #624 6/6\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_red_square",
+              "unicode": "1f7e5"
+            },
+            {
+              "type": "emoji",
+              "name": "large_red_square",
+              "unicode": "1f7e5"
+            },
+            {
+              "type": "emoji",
+              "name": "large_red_square",
+              "unicode": "1f7e5"
+            },
+            {
+              "type": "emoji",
+              "name": "large_red_square",
+              "unicode": "1f7e5"
+            },
+            {
+              "type": "emoji",
+              "name": "large_red_square",
+              "unicode": "1f7e5"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\nFound: 8/9 (88.9%)\nCurrent Streak: 3 (max 4)\n#Bandle #Heardle #Wordle\n\n"
+            },
+            {
+              "type": "link",
+              "url": "https://bandle.app/"
+            },
+            {
+              "type": "text",
+              "text": "\n\n#ows72 "
+            },
+            {
+              "type": "emoji",
+              "name": "mag_right",
+              "unicode": "1f50e"
+            },
+            {
+              "type": "text",
+              "text": " 3/5 (02:08)\n"
+            },
+            {
+              "type": "emoji",
+              "name": "star",
+              "unicode": "2b50"
+            },
+            {
+              "type": "emoji",
+              "name": "star",
+              "unicode": "2b50"
+            },
+            {
+              "type": "emoji",
+              "name": "star",
+              "unicode": "2b50"
+            },
+            {
+              "type": "text",
+              "text": "\nstreak: 4 "
+            },
+            {
+              "type": "emoji",
+              "name": "fire",
+              "unicode": "1f525"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "link",
+              "url": "http://onewordsearch.com",
+              "text": "onewordsearch.com"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "channel": "C06D1J4T54J",
+  "event_ts": "1714382813.712429",
+  "channel_type": "channel"
+}

--- a/src/resources/test/event_samples/event_waffle_score_long_text_before.json
+++ b/src/resources/test/event_samples/event_waffle_score_long_text_before.json
@@ -1,0 +1,870 @@
+{
+  "user": "{{USER_INFO}}",
+  "type": "message",
+  "ts": "1714382813.712429",
+  "client_msg_id": "eb5e22c3-0657-4879-bc5c-0c093248cad4",
+  "text": "sp a c e ?\n\n#waffle828 0/5\n\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n:large_green_square::white_large_square::large_green_square::white_large_square::large_green_square:\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n:large_green_square::white_large_square::large_green_square::white_large_square::large_green_square:\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n\n:fire: streak: 4\n<http://wafflegame.net|wafflegame.net>",
+  "team": "T06DQBGR53J",
+  "blocks": [
+    {
+      "type": "rich_text",
+      "block_id": "RN7Xk",
+      "elements": [
+        {
+          "type": "rich_text_section",
+          "elements": [
+            {
+              "type": "text",
+              "text": "#Worldle #832 (02.05.2024) X/6 (97%)\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_left",
+              "unicode": "2b05-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_right",
+              "unicode": "27a1-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_right",
+              "unicode": "27a1-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_lower_left",
+              "unicode": "2199-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_yellow_square",
+              "unicode": "1f7e8"
+            },
+            {
+              "type": "emoji",
+              "name": "black_large_square",
+              "unicode": "2b1b"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_up",
+              "unicode": "2b06-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_yellow_square",
+              "unicode": "1f7e8"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_up",
+              "unicode": "2b06-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "coin",
+              "unicode": "1fa99"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "link",
+              "url": "https://worldle.teuteuf.fr"
+            },
+            {
+              "type": "text",
+              "text": "\n\n"
+            },
+            {
+              "type": "emoji",
+              "name": "camera",
+              "unicode": "1f4f7"
+            },
+            {
+              "type": "text",
+              "text": " #WhereTaken"
+            },
+            {
+              "type": "emoji",
+              "name": "earth_americas",
+              "unicode": "1f30e"
+            },
+            {
+              "type": "text",
+              "text": " #431 (02.05.2024) 4/6\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_yellow_square",
+              "unicode": "1f7e8"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_lower_left",
+              "unicode": "2199-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_upper_left",
+              "unicode": "2196-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "arrow_down",
+              "unicode": "2b07-fe0f"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "large_blue_square",
+              "unicode": "1f7e6"
+            },
+            {
+              "type": "emoji",
+              "name": "tada",
+              "unicode": "1f389"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "star",
+              "unicode": "2b50"
+            },
+            {
+              "type": "emoji",
+              "name": "star",
+              "unicode": "2b50"
+            },
+            {
+              "type": "text",
+              "text": "\n\n"
+            },
+            {
+              "type": "link",
+              "url": "http://wheretaken.teuteuf.fr",
+              "text": "wheretaken.teuteuf.fr"
+            },
+            {
+              "type": "text",
+              "text": "\n\n#WhenTaken #65 (02.05.2024)\n\nI scored 811/1000 "
+            },
+            {
+              "type": "emoji",
+              "name": "tada",
+              "unicode": "1f389"
+            },
+            {
+              "type": "text",
+              "text": "\n\n"
+            },
+            {
+              "type": "emoji",
+              "name": "one",
+              "unicode": "0031-fe0f-20e3"
+            },
+            {
+              "type": "text",
+              "text": " "
+            },
+            {
+              "type": "emoji",
+              "name": "round_pushpin",
+              "unicode": "1f4cd"
+            },
+            {
+              "type": "text",
+              "text": " 758 km - "
+            },
+            {
+              "type": "emoji",
+              "name": "spiral_calendar_pad",
+              "unicode": "1f5d3-fe0f"
+            },
+            {
+              "type": "text",
+              "text": " 2 yrs - "
+            },
+            {
+              "type": "emoji",
+              "name": "zap",
+              "unicode": "26a1"
+            },
+            {
+              "type": "text",
+              "text": " 175 / 200\n"
+            },
+            {
+              "type": "emoji",
+              "name": "two",
+              "unicode": "0032-fe0f-20e3"
+            },
+            {
+              "type": "text",
+              "text": " "
+            },
+            {
+              "type": "emoji",
+              "name": "round_pushpin",
+              "unicode": "1f4cd"
+            },
+            {
+              "type": "text",
+              "text": " 5 km - "
+            },
+            {
+              "type": "emoji",
+              "name": "spiral_calendar_pad",
+              "unicode": "1f5d3-fe0f"
+            },
+            {
+              "type": "text",
+              "text": " 10 yrs - "
+            },
+            {
+              "type": "emoji",
+              "name": "zap",
+              "unicode": "26a1"
+            },
+            {
+              "type": "text",
+              "text": " 185 / 200\n"
+            },
+            {
+              "type": "emoji",
+              "name": "three",
+              "unicode": "0033-fe0f-20e3"
+            },
+            {
+              "type": "text",
+              "text": " "
+            },
+            {
+              "type": "emoji",
+              "name": "round_pushpin",
+              "unicode": "1f4cd"
+            },
+            {
+              "type": "text",
+              "text": " 2800 km - "
+            },
+            {
+              "type": "emoji",
+              "name": "spiral_calendar_pad",
+              "unicode": "1f5d3-fe0f"
+            },
+            {
+              "type": "text",
+              "text": " 2 yrs - "
+            },
+            {
+              "type": "emoji",
+              "name": "zap",
+              "unicode": "26a1"
+            },
+            {
+              "type": "text",
+              "text": " 140 / 200\n"
+            },
+            {
+              "type": "emoji",
+              "name": "four",
+              "unicode": "0034-fe0f-20e3"
+            },
+            {
+              "type": "text",
+              "text": " "
+            },
+            {
+              "type": "emoji",
+              "name": "round_pushpin",
+              "unicode": "1f4cd"
+            },
+            {
+              "type": "text",
+              "text": " 62 km - "
+            },
+            {
+              "type": "emoji",
+              "name": "spiral_calendar_pad",
+              "unicode": "1f5d3-fe0f"
+            },
+            {
+              "type": "text",
+              "text": " 9 yrs - "
+            },
+            {
+              "type": "emoji",
+              "name": "zap",
+              "unicode": "26a1"
+            },
+            {
+              "type": "text",
+              "text": " 184 / 200\n"
+            },
+            {
+              "type": "emoji",
+              "name": "five",
+              "unicode": "0035-fe0f-20e3"
+            },
+            {
+              "type": "text",
+              "text": " "
+            },
+            {
+              "type": "emoji",
+              "name": "round_pushpin",
+              "unicode": "1f4cd"
+            },
+            {
+              "type": "text",
+              "text": " 3570 km - "
+            },
+            {
+              "type": "emoji",
+              "name": "spiral_calendar_pad",
+              "unicode": "1f5d3-fe0f"
+            },
+            {
+              "type": "text",
+              "text": " 6 yrs - "
+            },
+            {
+              "type": "emoji",
+              "name": "zap",
+              "unicode": "26a1"
+            },
+            {
+              "type": "text",
+              "text": " 127 / 200\n\n"
+            },
+            {
+              "type": "link",
+              "url": "https://whentaken.com"
+            },
+            {
+              "type": "text",
+              "text": "\n\nBandle #624 6/6\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_red_square",
+              "unicode": "1f7e5"
+            },
+            {
+              "type": "emoji",
+              "name": "large_red_square",
+              "unicode": "1f7e5"
+            },
+            {
+              "type": "emoji",
+              "name": "large_red_square",
+              "unicode": "1f7e5"
+            },
+            {
+              "type": "emoji",
+              "name": "large_red_square",
+              "unicode": "1f7e5"
+            },
+            {
+              "type": "emoji",
+              "name": "large_red_square",
+              "unicode": "1f7e5"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\nFound: 8/9 (88.9%)\nCurrent Streak: 3 (max 4)\n#Bandle #Heardle #Wordle\n\n"
+            },
+            {
+              "type": "link",
+              "url": "https://bandle.app/"
+            },
+            {
+              "type": "text",
+              "text": "\n\n#ows72 "
+            },
+            {
+              "type": "emoji",
+              "name": "mag_right",
+              "unicode": "1f50e"
+            },
+            {
+              "type": "text",
+              "text": " 3/5 (02:08)\n"
+            },
+            {
+              "type": "emoji",
+              "name": "star",
+              "unicode": "2b50"
+            },
+            {
+              "type": "emoji",
+              "name": "star",
+              "unicode": "2b50"
+            },
+            {
+              "type": "emoji",
+              "name": "star",
+              "unicode": "2b50"
+            },
+            {
+              "type": "text",
+              "text": "\nstreak: 4 "
+            },
+            {
+              "type": "emoji",
+              "name": "fire",
+              "unicode": "1f525"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "link",
+              "url": "http://onewordsearch.com",
+              "text": "onewordsearch.com"
+            },
+            {
+              "type": "text",
+              "text": "\n\n#waffle832 3/5\n\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n\n"
+            },
+            {
+              "type": "emoji",
+              "name": "fire",
+              "unicode": "1f525"
+            },
+            {
+              "type": "text",
+              "text": " streak: 6\n"
+            },
+            {
+              "type": "link",
+              "url": "http://wafflegame.net",
+              "text": "wafflegame.net"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "channel": "C06D1J4T54J",
+  "event_ts": "1714382813.712429",
+  "channel_type": "channel"
+}

--- a/src/resources/test/event_samples/event_waffle_score_nothing_else.json
+++ b/src/resources/test/event_samples/event_waffle_score_nothing_else.json
@@ -1,0 +1,187 @@
+{
+  "user": "{{USER_INFO}}",
+  "type": "message",
+  "ts": "1714382813.712429",
+  "client_msg_id": "eb5e22c3-0657-4879-bc5c-0c093248cad4",
+  "text": "#waffle828 0/5\n\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n:large_green_square::white_large_square::large_green_square::white_large_square::large_green_square:\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n:large_green_square::white_large_square::large_green_square::white_large_square::large_green_square:\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n\n:fire: streak: 4\n<http://wafflegame.net|wafflegame.net>",
+  "team": "T06DQBGR53J",
+  "blocks": [
+    {
+      "type": "rich_text",
+      "block_id": "YC/lV",
+      "elements": [
+        {
+          "type": "rich_text_section",
+          "elements": [
+            {
+              "type": "text",
+              "text": "#waffle828 0/5\n\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n\n"
+            },
+            {
+              "type": "emoji",
+              "name": "fire",
+              "unicode": "1f525"
+            },
+            {
+              "type": "text",
+              "text": " streak: 4\n"
+            },
+            {
+              "type": "link",
+              "url": "http://wafflegame.net",
+              "text": "wafflegame.net"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "channel": "C06D1J4T54J",
+  "event_ts": "1714382813.712429",
+  "channel_type": "channel"
+}

--- a/src/resources/test/event_samples/event_waffle_score_short_text_after.json
+++ b/src/resources/test/event_samples/event_waffle_score_short_text_after.json
@@ -1,0 +1,187 @@
+{
+  "user": "{{USER_INFO}}",
+  "type": "message",
+  "ts": "1714382813.712429",
+  "client_msg_id": "eb5e22c3-0657-4879-bc5c-0c093248cad4",
+  "text": "sp a c e ?\n\n#waffle828 0/5\n\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n:large_green_square::white_large_square::large_green_square::white_large_square::large_green_square:\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n:large_green_square::white_large_square::large_green_square::white_large_square::large_green_square:\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n\n:fire: streak: 4\n<http://wafflegame.net|wafflegame.net>",
+  "team": "T06DQBGR53J",
+  "blocks": [
+    {
+      "type": "rich_text",
+      "block_id": "YC/lV",
+      "elements": [
+        {
+          "type": "rich_text_section",
+          "elements": [
+            {
+              "type": "text",
+              "text": "#waffle828 0/5\n\nsp a c e ?\n\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n\n"
+            },
+            {
+              "type": "emoji",
+              "name": "fire",
+              "unicode": "1f525"
+            },
+            {
+              "type": "text",
+              "text": " streak: 4\n"
+            },
+            {
+              "type": "link",
+              "url": "http://wafflegame.net",
+              "text": "wafflegame.net"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "channel": "C06D1J4T54J",
+  "event_ts": "1714382813.712429",
+  "channel_type": "channel"
+}

--- a/src/resources/test/event_samples/event_waffle_score_short_text_before.json
+++ b/src/resources/test/event_samples/event_waffle_score_short_text_before.json
@@ -1,0 +1,187 @@
+{
+  "user": "{{USER_INFO}}",
+  "type": "message",
+  "ts": "1714382813.712429",
+  "client_msg_id": "eb5e22c3-0657-4879-bc5c-0c093248cad4",
+  "text": "sp a c e ?\n\n#waffle828 0/5\n\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n:large_green_square::white_large_square::large_green_square::white_large_square::large_green_square:\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n:large_green_square::white_large_square::large_green_square::white_large_square::large_green_square:\n:large_green_square::large_green_square::large_green_square::large_green_square::large_green_square:\n\n:fire: streak: 4\n<http://wafflegame.net|wafflegame.net>",
+  "team": "T06DQBGR53J",
+  "blocks": [
+    {
+      "type": "rich_text",
+      "block_id": "YC/lV",
+      "elements": [
+        {
+          "type": "rich_text_section",
+          "elements": [
+            {
+              "type": "text",
+              "text": "sp a c e ?\n\n#waffle828 0/5\n\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "white_large_square",
+              "unicode": "2b1c"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "emoji",
+              "name": "large_green_square",
+              "unicode": "1f7e9"
+            },
+            {
+              "type": "text",
+              "text": "\n\n"
+            },
+            {
+              "type": "emoji",
+              "name": "fire",
+              "unicode": "1f525"
+            },
+            {
+              "type": "text",
+              "text": " streak: 4\n"
+            },
+            {
+              "type": "link",
+              "url": "http://wafflegame.net",
+              "text": "wafflegame.net"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "channel": "C06D1J4T54J",
+  "event_ts": "1714382813.712429",
+  "channel_type": "channel"
+}


### PR DESCRIPTION
The cause of this behaviour is with the Event class, where the means for extracting the Score and Streak attributes were only designed with handling Slack posts that contain only a wafflegame.net submission. 

My changes have updated this with an implementation that can filter through miscellanious text to pull the right values, and include unit tests to verify it does as required. I have also introduced a new debug log to better indicate if Slack has sent us an event that meets the criteria of containing the string '#waffle' but nothing else of use.

Closes #57 